### PR TITLE
Add 2017-2019 Tour de France winners

### DIFF
--- a/lib/Acme/MetaSyntactic/tour_de_france.pm
+++ b/lib/Acme/MetaSyntactic/tour_de_france.pm
@@ -31,6 +31,9 @@ The winners from 1903 onwards are:
 
 =pod
 
+    2019   Egan Bernal           COL
+    2018   Geraint Thomas        GBR
+    2017   Christopher Froome    GBR
     2016   Christopher Froome    GBR
     2015   Christopher Froome    GBR
     2014   Vincenzo Nibali       ITA


### PR DESCRIPTION
From https://en.wikipedia.org/wiki/List_of_Tour_de_France_general_classification_winners#Winners